### PR TITLE
Fixed image sizes after uploading images

### DIFF
--- a/modules/uploads.php
+++ b/modules/uploads.php
@@ -408,8 +408,8 @@ class Uploads {
 
 		$data = [
 			$url, // URL
-			false, // width
-			false, // height
+			$size['width'],
+			$size['height'],
 			(bool) $real_size // image is intermediate
 		];
 		return $data;


### PR DESCRIPTION
When uploading an image, the possible image sizes in response back to
browser must be returned properly instead of ‘false’ for width and
‘false’ for height. We ran into this problem in working with Caption.
Wordpress requires the image width to convert the caption into proper
caption shortcode which will be stored in the database. You can
reproduce this problem by the following steps:
- Create new post
- Add the title
- Add an image
- Save post
- Add image caption.
- Save post
Result: the caption will be gone after the page is loaded again.

Also, after uploading, in Insert Media screen, “ATTACHMENT DISPLAY
SETTINGS” section, Size dropdownbox, you will have,
Thumbnail - False, Medium - False, Large - False.
These sizes should come up with their actual size like the Full Size.

![image](https://cloud.githubusercontent.com/assets/3193353/5932997/b365b7e0-a70c-11e4-9bc1-b95bb480a0b4.png)
